### PR TITLE
Allows Consumer Pass Argument for Return Type of `createMutatorStore`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 A tiny data fetcher for [Nano Stores](https://github.com/nanostores/nanostores).
 
-- **Small**. 1.64 Kb (minified and gzipped).
+- **Small**. 1.62 Kb (minified and gzipped).
 - **Familiar DX**. If you've used [`swr`](https://swr.vercel.app/) or
 [`react-query`](https://react-query-v3.tanstack.com/), you'll get the same treatment,
 but for 10-20% of the size.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 A tiny data fetcher for [Nano Stores](https://github.com/nanostores/nanostores).
 
-- **Small**. 1.63 Kb (minified and gzipped).
+- **Small**. 1.64 Kb (minified and gzipped).
 - **Familiar DX**. If you've used [`swr`](https://swr.vercel.app/) or
 [`react-query`](https://react-query-v3.tanstack.com/), you'll get the same treatment,
 but for 10-20% of the size.

--- a/lib/__tests__/type.test-d.ts
+++ b/lib/__tests__/type.test-d.ts
@@ -58,6 +58,11 @@ describe("types", () => {
     $mutate.mutate({ msg1: "" });
     expectTypeOf(error).toEqualTypeOf<Error | undefined>();
     expectTypeOf(data).toEqualTypeOf<Result | undefined>();
+
+    createMutator<Data, Result, Error>(
+      // @ts-expect-error: incorrect Result
+      async () => ({ res: "200" })
+    );
   });
 
   test("mutator accepts void data", () => {

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -69,15 +69,15 @@ export type ManualMutator<Data = void, Result = unknown> = (args: {
     shouldRevalidate?: boolean
   ) => [(newValue?: T) => void, T | undefined];
 }) => Promise<Result>;
-export type MutateCb<Data> = Data extends void
-  ? () => Promise<unknown>
-  : (data: Data) => Promise<unknown>;
+export type MutateCb<Data, Result = unknown> = Data extends void
+  ? () => Promise<Result>
+  : (data: Data) => Promise<Result>;
 export type MutatorStore<Data = void, Result = unknown, E = Error> = MapStore<{
-  mutate: MutateCb<Data>;
+  mutate: MutateCb<Data, Result>;
   data?: Result;
   loading?: boolean;
   error?: E;
-}> & { mutate: MutateCb<Data> };
+}> & { mutate: MutateCb<Data, Result> };
 
 export const nanoquery = ({
   cache = new Map(),
@@ -339,7 +339,7 @@ export const nanoquery = ({
         store.set({
           error: void 0,
           data: void 0,
-          mutate: mutate as MutateCb<Data>,
+          mutate: mutate as MutateCb<Data, Result>,
           ...loading,
         });
         const result = await newMutator({
@@ -372,10 +372,10 @@ export const nanoquery = ({
       }
     };
     const store: MutatorStore<Data, Result, E> = map({
-      mutate: mutate as MutateCb<Data>,
+      mutate: mutate as MutateCb<Data, Result>,
       ...notLoading,
     });
-    store.mutate = mutate as MutateCb<Data>;
+    store.mutate = mutate as MutateCb<Data, Result>;
     return store;
   }
 

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
       "import": {
         "./dist/nanoquery.js": "{ nanoquery }"
       },
-      "limit": "1631 B"
+      "limit": "1635 B"
     }
   ],
   "repository": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
       "import": {
         "./dist/nanoquery.js": "{ nanoquery }"
       },
-      "limit": "1635 B"
+      "limit": "1626 B"
     }
   ],
   "repository": {


### PR DESCRIPTION
## Description

Allows consuming code to pass a type argument for the return value of `createMutatorStore`. Really, it just re-uses the `Response` argument and passes it through to `MutatorCb`

## Usage

```ts
const doThing = async (): Promise<{id: string}> => {
  const r = await fetch("/hello/world");
  return r.json();
};

const $createThing = createMutatorStore<
  { hello: "world" },
  { id: string; description: string }
>(() => doThing()); // will correctly error b/c doThing() is missing `description`
```

<img width="761" alt="Screenshot 2024-02-05 at 5 07 45 PM" src="https://github.com/nanostores/query/assets/7387001/061178a6-7d0f-49f8-b444-51407a76dc57">