### PR TITLE
Custom `dedupeTime` depending on fetch success (solution for #23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,3 +265,30 @@ But if your store is somehow dependant on other store, but it shouldn't be refle
 ```ts
 onSet($someOutsideFactor, $specificStore.invalidate)
 ```
+
+### Custom `dedupeTime` depending on fetch success
+You can set `dedupeTime` to a function that calculates the dedupeTime for every fetch separately.
+
+The function gets the following parameters:
+- `v` the current `{data, loading, error}` of the store
+- `lastFetchTime` when the most recent fetch was last started (or completed, if it was successful)
+- `consequentErrors` how many consequent errors has this key had. Useful for e.g. exponential back-off strategies.
+
+It should return the calculated dedupeTime in ms.
+
+For example, suppose you want successful fetches to be deduped every 60 seconds, but erroneous fetches to be retried earlier.
+
+```ts
+export const $store = createFetcherStore([key1,key2],
+    {
+        dedupeTime: (v, lastFetchTime, consequentErrors): number => {
+            if (consequentErrors > 0) {
+                return 1000;
+            }
+            return defaultDedupeTime;
+        }
+     }
+)
+```
+
+

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -179,7 +179,7 @@ export const nanoquery = ({
       // Possibly preserving previous cache
       settings.onError?.(error);
       set({ data: store.value.data, error, ...notLoading });
-      _errorCount.set(key, _errorCount.get(key) ?? 0 + 1);
+      _errorCount.set(key, (_errorCount.get(key) ?? 0) + 1);
     } finally {
       finishTask();
       _runningFetches.delete(key);


### PR DESCRIPTION

Allows to set `dedupeTime` to either a fixed number of milliseconds, or to a function that calculates the dedupeTime for every fetch separately. This allows creating a backoff mechanism if necessary, without too much overhead.
