### PR TITLE
fix: support react native

### DIFF
--- a/lib/main.ts
+++ b/lib/main.ts
@@ -636,7 +636,8 @@ type Events = {
 
 const subscribe = (name: string, fn: Fn) => {
   const isServer = typeof window === "undefined";
-  if (!isServer && window.hasOwnProperty("addEventListener")) {
+  const isReactNative = typeof navigator !== "undefined" && navigator.product === "ReactNative";
+  if (!isServer && !isReactNative) {
     addEventListener(name, fn);
   }
 };

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -636,7 +636,7 @@ type Events = {
 
 const subscribe = (name: string, fn: Fn) => {
   const isServer = typeof window === "undefined";
-  if (!isServer) {
+  if (!isServer && window.hasOwnProperty("addEventListener")) {
     addEventListener(name, fn);
   }
 };


### PR DESCRIPTION
`query` is failing when it is used inside `react-native`.
The reason is because it is trying to execute `addEventListener`, which doesn't exist in React Native.
We are already checking `typeof window === 'undefined` for Server, we just need to add one more extra check to see if `addEventListener` exist in `window`

![IMG_0047](https://github.com/nanostores/query/assets/8596374/2cec6501-6664-4e9f-97d2-b2fe2e8250ab)
