### PR TITLE
Hide type of arguments on first example

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ First, we define the context. It allows us to share the default fetcher implemen
 import { nanoquery } from '@nanostores/query';
 
 export const [createFetcherStore, createMutatorStore] = nanoquery({
-  fetcher: (...keys: (string | number)[]) => fetch(keys.join('')).then((r) => r.json()),
+  fetcher: (...keys) => fetch(keys.join('')).then((r) => r.json()),
 });
 ```
 


### PR DESCRIPTION
If you copy the code from the first example, a TypeScript conlflict will occur. 
<img width="734" alt="Screenshot 2024-09-06 at 01 32 50" src="https://github.com/user-attachments/assets/9f84671c-c6db-4bff-8487-729ba7defa20">

That's why it's better to remove argument typing, because `SomeKeys` are not available outside the package, and the Fetcher type is already mapped in the function